### PR TITLE
fix type inconsistent

### DIFF
--- a/src/spike_buffer.cu
+++ b/src/spike_buffer.cu
@@ -519,7 +519,7 @@ int SpikeBufferInit(NetConnection *net_connection, int max_spike_buffer_size)
   gpuErrchk( cudaPeekAtLastError() );
   gpuErrchk( cudaDeviceSynchronize() );
   gpuErrchk(cudaMemset(d_LastSpikeHeight, 0,
-		       n_spike_buffers*sizeof(unsigned short)));
+		       n_spike_buffers*sizeof(float)));
 
   delete[] h_ConnectionGroupSize;
   delete[] h_ConnectionGroupDelay;


### PR DESCRIPTION
There are some more like this, please check.
What I am more concerned about is that this value is int in nest, can it also be here? Or unsigned char, because this involves memory usage, in the case of a large number of nodes.（Not just this, but something else)